### PR TITLE
http/render: Update import path of moved package.

### DIFF
--- a/http/render/templating.go
+++ b/http/render/templating.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cryptix/go/logging"
 	"github.com/gorilla/mux"
 	"github.com/oxtoacart/bpool"
-	"github.com/shurcooL/go/vfs/httpfs/html/vfstemplate"
+	"github.com/shurcooL/httpfs/html/vfstemplate"
 	"gopkg.in/errgo.v1"
 )
 


### PR DESCRIPTION
This package has moved out into a standalone repository. See https://github.com/shurcooL/httpfs/commit/0a8f492bc2c6ec4744aa778731278f842c30d185.
